### PR TITLE
Add subresource-integrity hash to jquery import

### DIFF
--- a/index.html
+++ b/index.html
@@ -522,7 +522,7 @@
 	</div>
 
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js" integrity="sha384-6ePHh72Rl3hKio4HiJ841psfsRJveeS+aLoaEf3BWfS+gTF0XdAqku2ka8VddikM" crossorigin="anonymous"></script>
     <!-- Include all compiled plugins (below), or include individual files as needed -->
     <script src="js/bootstrap.min.js"></script>
 


### PR DESCRIPTION
This protects against your third party host (in this case https://ajax.googleapis.com) serving you a modified version of jquery and exploiting your users.

See https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity

Generated with https://www.srihash.org/